### PR TITLE
closes #1 added git issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,47 @@
+name: Bug Report
+description: Submit a bug report
+title: "[Bug Report] Bug title"
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
+
+  - type: textarea
+    id: code-example
+    attributes:
+      label: Code example
+      description: |
+        Provide an example code or a stack trace.
+        This will be automatically formatted into code, so no need for backticks.
+      render: shell
+
+  - type: textarea
+    id: system-info
+    attributes:
+      label: System info
+      description: |
+        Describe the characteristic of your environment:
+        * What OS/version you're using.
+        * Python version
+
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add any other context about the problem here.
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: >
+            I have checked that there is no similar [issue](https://github.com/tobirohrer/python-project-template/issues)
+            in the repo.
+          required: true

--- a/.github/ISSUE_TEMPLATE/proposal.yml
+++ b/.github/ISSUE_TEMPLATE/proposal.yml
@@ -1,0 +1,47 @@
+name: Proposal
+description: Propose changes that are not fixing bugs
+title: "[Proposal] Proposal title"
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: A clear and concise description of the proposal.
+    validations:
+      required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: |
+        Please outline the motivation for the proposal.
+
+  - type: textarea
+    id: pitch
+    attributes:
+      label: Pitch
+      description: A clear and concise description of what you want to happen.
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives
+      description: A clear and concise description of any alternative solutions or features you've considered, if any.
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add any other context or screenshots about the feature request here.
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: >
+            I have checked that there is no similar [issue](https://github.com/tobirohrer/python-project-template/issues)
+            in the repo.
+          required: true

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,17 @@
+name: Question
+description: Ask a question
+title: "[Question] Question title"
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: >
+        Do you have any questions related to this project?
+        
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      description: Your question
+    validations:
+      required: true


### PR DESCRIPTION
Adds git issue forms. More details about the forms can be found [here](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms) 